### PR TITLE
docs: fix Django typo to FastAPI in App.vue heading

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,7 +15,7 @@ onMounted(async () => {
 
 <template>
   <main style="padding:2rem;font-family:sans-serif">
-    <h1>Django + Vue</h1>
+    <h1>FastAPI + Vue</h1>
     <p>Health: {{ msg }}</p>
   </main>
 </template>


### PR DESCRIPTION
"Hi @tomekmakuch, I have updated the heading in App.vue from 'Django + Vue' to 'FastAPI + Vue' as requested. Ready for review!"